### PR TITLE
no resize, no stty on MS Windows

### DIFF
--- a/ReadKey.pm
+++ b/ReadKey.pm
@@ -390,7 +390,7 @@ sub GetTerminalSize
         push( @fail, "COLUMNS and LINES environment variables" );
     }
 
-    if ( @results < 4 )
+    if ( @results < 4 && $^O ne 'MSWin32')
     {
         my ($prog) = "resize";
 
@@ -425,7 +425,7 @@ sub GetTerminalSize
         push( @fail, "resize program" );
     }
 
-    if ( @results < 4 )
+    if ( @results < 4 && $^O ne 'MSWin32' )
     {
         my ($prog) = "stty size";
 


### PR DESCRIPTION
There are no resize and no stty on MS Windows; however they are sometimes in PATH as cygwin executables which make troubles. 

This patch completely skips two UNIX only parts on MS Windows.