### PR TITLE
static+consting+cc warnings+PERL_NO_GET_CONTEXT

### DIFF
--- a/ReadKey.xs
+++ b/ReadKey.xs
@@ -1,5 +1,6 @@
 /* -*-C-*- */
 
+#define PERL_NO_GET_CONTEXT     /* we want efficiency */
 #include "EXTERN.h"
 #include "perl.h"
 #include "XSUB.h"
@@ -378,41 +379,41 @@
 #include "cchars.h"
 
 
-int GetTermSizeVIO _((PerlIO * file,
+STATIC int GetTermSizeVIO _((pTHX_ PerlIO * file,
 	int * retwidth, int * retheight, 
 	int * xpix, int * ypix));
 
-int GetTermSizeGWINSZ _((PerlIO * file,
+STATIC int GetTermSizeGWINSZ _((pTHX_ PerlIO * file,
 	int * retwidth, int * retheight, 
 	int * xpix, int * ypix));
 
-int GetTermSizeGSIZE _((PerlIO * file,
+STATIC int GetTermSizeGSIZE _((pTHX_ PerlIO * file,
 	int * retwidth, int * retheight, 
 	int * xpix, int * ypix));
 
-int GetTermSizeWin32 _((PerlIO * file,
+STATIC int GetTermSizeWin32 _((pTHX_ PerlIO * file,
 	int * retwidth, int * retheight,
 	int * xpix, int * ypix));
 
-int SetTerminalSize _((PerlIO * file,
+STATIC int SetTerminalSize _((pTHX_ PerlIO * file,
 	int width, int height, 
 	int xpix, int ypix));
 
-void ReadMode _((PerlIO * file,int mode));
+STATIC void ReadMode _((pTHX_ PerlIO * file,int mode));
 
-int pollfile _((PerlIO * file, double delay));
+STATIC int pollfile _((pTHX_ PerlIO * file, double delay));
 
-int setnodelay _((PerlIO * file, int mode));
+STATIC int setnodelay _((pTHX_ PerlIO * file, int mode));
 
-int selectfile _((PerlIO * file, double delay));
+STATIC int selectfile _((pTHX_ PerlIO * file, double delay));
 
-int Win32PeekChar _((PerlIO * file, double delay, char * key));
+STATIC int Win32PeekChar _((pTHX_ PerlIO * file, U32 delay, char * key));
 
-int getspeed _((PerlIO * file, I32 *in, I32 * out ));
+STATIC int getspeed _((pTHX_ PerlIO * file, I32 *in, I32 * out ));
 
 
 #ifdef VIOMODE
-int GetTermSizeVIO(PerlIO *file,int *retwidth,int *retheight,int *xpix,int *ypix)
+int GetTermSizeVIO(pTHX_ PerlIO *file,int *retwidth,int *retheight,int *xpix,int *ypix)
 {
 	/*int handle=PerlIO_fileno(file);
 
@@ -434,7 +435,7 @@ int GetTermSizeVIO(PerlIO *file,int *retwidth,int *retheight,int *xpix,int *ypix
         return 0;
 }
 #else
-int GetTermSizeVIO(PerlIO *file,int * retwidth,int *retheight, int *xpix,int *ypix)
+int GetTermSizeVIO(pTHX_ PerlIO *file,int * retwidth,int *retheight, int *xpix,int *ypix)
 {
 	croak("TermSizeVIO is not implemented on this architecture");
         return 0;
@@ -443,7 +444,7 @@ int GetTermSizeVIO(PerlIO *file,int * retwidth,int *retheight, int *xpix,int *yp
 
 
 #if defined(TIOCGWINSZ) && !defined(DONT_USE_GWINSZ)
-int GetTermSizeGWINSZ(PerlIO *file,int *retwidth,int *retheight,int *xpix,int *ypix)
+int GetTermSizeGWINSZ(pTHX_ PerlIO *file,int *retwidth,int *retheight,int *xpix,int *ypix)
 {
 	int handle=PerlIO_fileno(file);
 	struct winsize w;
@@ -458,7 +459,7 @@ int GetTermSizeGWINSZ(PerlIO *file,int *retwidth,int *retheight,int *xpix,int *y
 
 }
 #else
-int GetTermSizeGWINSZ(PerlIO *file,int *retwidth,int *retheight,int *xpix,int *ypix)
+int GetTermSizeGWINSZ(pTHX_ PerlIO *file,int *retwidth,int *retheight,int *xpix,int *ypix)
 {
 	croak("TermSizeGWINSZ is not implemented on this architecture");
         return 0;
@@ -466,7 +467,7 @@ int GetTermSizeGWINSZ(PerlIO *file,int *retwidth,int *retheight,int *xpix,int *y
 #endif
 
 #if (!defined(TIOCGWINSZ) || defined(DONT_USE_GWINSZ)) && (defined(TIOCGSIZE) && !defined(DONT_USE_GSIZE))
-int GetTermSizeGSIZE(PerlIO *file,int *retwidth,int *retheight,int *xpix,int *ypix)
+int GetTermSizeGSIZE(pTHX_ PerlIO *file,int *retwidth,int *retheight,int *xpix,int *ypix)
 {
 	int handle=PerlIO_fileno(file);
 
@@ -481,7 +482,7 @@ int GetTermSizeGSIZE(PerlIO *file,int *retwidth,int *retheight,int *xpix,int *yp
 	}
 }
 #else
-int GetTermSizeGSIZE(PerlIO *file,int *retwidth,int *retheight,int *xpix,int *ypix)
+int GetTermSizeGSIZE(pTHX_ PerlIO *file,int *retwidth,int *retheight,int *xpix,int *ypix)
 {
 	croak("TermSizeGSIZE is not implemented on this architecture");
         return 0;
@@ -489,7 +490,7 @@ int GetTermSizeGSIZE(PerlIO *file,int *retwidth,int *retheight,int *xpix,int *yp
 #endif
 
 #ifdef USE_WIN32
-int GetTermSizeWin32(PerlIO *file,int *retwidth,int *retheight,int *xpix,int *ypix)
+int GetTermSizeWin32(pTHX_ PerlIO *file,int *retwidth,int *retheight,int *xpix,int *ypix)
 {
 	int handle=PerlIO_fileno(file);
 	HANDLE whnd = (HANDLE)_get_osfhandle(handle);
@@ -512,7 +513,7 @@ int GetTermSizeWin32(PerlIO *file,int *retwidth,int *retheight,int *xpix,int *yp
 		return -1;
 }
 #else
-int GetTermSizeWin32(PerlIO *file,int *retwidth,int *retheight,int *xpix,int *ypix)
+int GetTermSizeWin32(pTHX_ PerlIO *file,int *retwidth,int *retheight,int *xpix,int *ypix)
 {
 	croak("TermSizeWin32 is not implemented on this architecture");
         return 0;
@@ -520,7 +521,7 @@ int GetTermSizeWin32(PerlIO *file,int *retwidth,int *retheight,int *xpix,int *yp
 #endif /* USE_WIN32 */
 
 
-int termsizeoptions() {
+STATIC int termsizeoptions() {
 	return	0
 #ifdef VIOMODE
 		| 1
@@ -538,9 +539,8 @@ int termsizeoptions() {
 }
 
 
-int SetTerminalSize(PerlIO *file,int width,int height,int xpix,int ypix)
+int SetTerminalSize(pTHX_ PerlIO *file,int width,int height,int xpix,int ypix)
 {
-	char buffer[10];
 	int handle=PerlIO_fileno(file);
 
 #ifdef VIOMODE
@@ -548,6 +548,7 @@ int SetTerminalSize(PerlIO *file,int width,int height,int xpix,int ypix)
 #else
 
 #if defined(TIOCSWINSZ) && !defined(DONT_USE_SWINSZ)
+	char buffer[10];
 	struct winsize w;
 
 	w.ws_col=width;
@@ -567,6 +568,7 @@ int SetTerminalSize(PerlIO *file,int width,int height,int xpix,int ypix)
 	}
 #else
 # if defined(TIOCSSIZE) && !defined(DONT_USE_SSIZE)
+	char buffer[10];
 	struct ttysize w;
 
 	w.ts_lines=height;
@@ -597,7 +599,7 @@ int SetTerminalSize(PerlIO *file,int width,int height,int xpix,int ypix)
 
 }
 
-I32 terminal_speeds[] = {
+STATIC const I32 terminal_speeds[] = {
 #ifdef B50
 	50, B50,
 #endif
@@ -661,10 +663,12 @@ I32 terminal_speeds[] = {
 	-1,-1
 };
 
-int getspeed(PerlIO *file,I32 *in, I32 *out)
+int getspeed(pTHX_ PerlIO *file,I32 *in, I32 *out)
 {
 	int handle=PerlIO_fileno(file);
+#if defined(I_TERMIOS) || defined(I_TERMIO) || defined(I_SGTTY)
 	int i;
+#endif
 #       ifdef I_TERMIOS
 	/* Posixy stuff */
 
@@ -765,10 +769,10 @@ struct tbuffer {
 #endif
 #endif
 
-HV * filehash; /* Used to store the original terminal settings for each handle*/
-HV * modehash; /* Used to record the current terminal "mode" for each handle*/
+static HV * filehash; /* Used to store the original terminal settings for each handle*/
+static HV * modehash; /* Used to record the current terminal "mode" for each handle*/
 
-void ReadMode(PerlIO *file,int mode)
+void ReadMode(pTHX_ PerlIO *file,int mode)
 {
 	dTHR;
 	int handle;
@@ -1453,7 +1457,7 @@ understand this syntax, either fix the checkwaiting call below, or define
 DONT_USE_SELECT. */
 
 #ifdef Have_select
-int selectfile(PerlIO *file,double delay)
+int selectfile(pTHX_ PerlIO *file,double delay)
 {
 	struct timeval t;
 	int handle=PerlIO_fileno(file);
@@ -1482,7 +1486,7 @@ int selectfile(PerlIO *file,double delay)
 }
 
 #else
-int selectfile(PerlIO *file, double delay)
+int selectfile(pTHX_ PerlIO *file, double delay)
 {
 	croak("select is not supported on this architecture");
 	return 0;
@@ -1490,7 +1494,7 @@ int selectfile(PerlIO *file, double delay)
 #endif
 
 #ifdef Have_nodelay
-int setnodelay(PerlIO *file, int mode)
+int setnodelay(pTHX_ PerlIO *file, int mode)
 {
 	int handle=PerlIO_fileno(file);
 	int flags;
@@ -1504,7 +1508,7 @@ int setnodelay(PerlIO *file, int mode)
 }
 
 #else
-int setnodelay(PerlIO *file, int mode) 
+int setnodelay(pTHX_ PerlIO *file, int mode)
 {
 	croak("setnodelay is not supported on this architecture");
 	return 0;
@@ -1512,7 +1516,7 @@ int setnodelay(PerlIO *file, int mode)
 #endif
 
 #ifdef Have_poll
-int pollfile(PerlIO *file,double delay)
+int pollfile(pTHX_ pTHX_ PerlIO *file,double delay)
 {
 	int handle=PerlIO_fileno(file);
 	struct pollfd fds;
@@ -1525,7 +1529,7 @@ int pollfile(PerlIO *file,double delay)
 	return (poll(&fds,1,(long)(delay * 1000.0))>0);
 } 
 #else
-int pollfile(PerlIO *file,double delay) 
+int pollfile(pTHX_ PerlIO *file,double delay)
 {
 	croak("pollfile is not supported on this architecture");
 	return 0;
@@ -1570,7 +1574,7 @@ typedef struct {
              goto again;                \
     } while (0)
 
-int Win32PeekChar(PerlIO *file,double delay,char *key)
+int Win32PeekChar(pTHX_ PerlIO *file,U32 delay,char *key)
 {
 	int handle;
 	HANDLE whnd;
@@ -1614,7 +1618,7 @@ again:
     }
 
 	if (delay > 0) {
-		if (WaitForSingleObject(whnd, delay * 1000.0) != WAIT_OBJECT_0)
+		if (WaitForSingleObject(whnd, delay * 1000) != WAIT_OBJECT_0)
 		{
 			return FALSE;
 		}
@@ -1706,7 +1710,7 @@ again:
 
 } 
 #else
-int Win32PeekChar(PerlIO *file, double delay,char *key) 
+int Win32PeekChar(pTHX_ PerlIO *file, U32 delay,char *key)
 {
 	croak("Win32PeekChar is not supported on this architecture");
 	return 0;
@@ -1714,7 +1718,7 @@ int Win32PeekChar(PerlIO *file, double delay,char *key)
 #endif
 
 
-int blockoptions() {
+STATIC int blockoptions() {
 	return	0
 #ifdef Have_nodelay
 		| 1
@@ -1731,7 +1735,7 @@ int blockoptions() {
 		;
 }
 
-int termoptions() {
+STATIC int termoptions() {
 	int i=0;
 #ifdef USE_TERMIOS
 	i=1;		
@@ -1759,6 +1763,10 @@ int
 selectfile(file,delay)
 	InputStream	file
 	double	delay
+CODE:
+	RETVAL = selectfile(aTHX_ file, delay);
+OUTPUT:
+	RETVAL
 
 # Clever, eh?
 void
@@ -1767,27 +1775,35 @@ SetReadMode(mode,file=STDIN)
 	InputStream	file
 	CODE:
 	{
-		ReadMode(file,mode);
+		ReadMode(aTHX_ file,mode);
 	}
 
 int
 setnodelay(file,mode)
 	InputStream	file
 	int	mode
+CODE:
+	RETVAL = setnodelay(aTHX_ file, mode);
+OUTPUT:
+	RETVAL
 
 int
 pollfile(file,delay)
 	InputStream	file
 	double	delay
+CODE:
+	RETVAL = pollfile(aTHX_ file, delay);
+OUTPUT:
+	RETVAL
 
 SV *
 Win32PeekChar(file, delay)
 	InputStream	file
-	double	delay
+	U32	delay
 	CODE:
 	{
 		char key;
-		if (Win32PeekChar(file, delay, &key))
+		if (Win32PeekChar(aTHX_ file, delay, &key))
 			RETVAL = newSVpv(&key, 1);
 		else
 			RETVAL = newSVsv(&PL_sv_undef);
@@ -1810,7 +1826,7 @@ GetTermSizeWin32(file=STDIN)
 	PPCODE:
 	{
 		int x,y,xpix,ypix;
-		if( GetTermSizeWin32(file,&x,&y,&xpix,&ypix)==0)
+		if( GetTermSizeWin32(aTHX_ file,&x,&y,&xpix,&ypix)==0)
 		{
 			EXTEND(sp, 4);
 			PUSHs(sv_2mortal(newSViv((IV)x)));
@@ -1830,7 +1846,7 @@ GetTermSizeVIO(file=STDIN)
 	PPCODE:
 	{
 		int x,y,xpix,ypix;
-		if( GetTermSizeVIO(file,&x,&y,&xpix,&ypix)==0)
+		if( GetTermSizeVIO(aTHX_ file,&x,&y,&xpix,&ypix)==0)
 		{
 			EXTEND(sp, 4);
 			PUSHs(sv_2mortal(newSViv((IV)x)));
@@ -1850,7 +1866,7 @@ GetTermSizeGWINSZ(file=STDIN)
 	PPCODE:
 	{
 		int x,y,xpix,ypix;
-		if( GetTermSizeGWINSZ(file,&x,&y,&xpix,&ypix)==0)
+		if( GetTermSizeGWINSZ(aTHX_ file,&x,&y,&xpix,&ypix)==0)
 		{
 			EXTEND(sp, 4);
 			PUSHs(sv_2mortal(newSViv((IV)x)));
@@ -1870,7 +1886,7 @@ GetTermSizeGSIZE(file=STDIN)
 	PPCODE:
 	{
 		int x,y,xpix,ypix;
-		if( GetTermSizeGSIZE(file,&x,&y,&xpix,&ypix)==0)
+		if( GetTermSizeGSIZE(aTHX_ file,&x,&y,&xpix,&ypix)==0)
 		{
 			EXTEND(sp, 4);
 			PUSHs(sv_2mortal(newSViv((IV)x)));
@@ -1893,7 +1909,7 @@ SetTerminalSize(width,height,xpix,ypix,file=STDIN)
 	InputStream	file
 	CODE:
 	{
-		RETVAL=SetTerminalSize(file,width,height,xpix,ypix);
+		RETVAL=SetTerminalSize(aTHX_ file,width,height,xpix,ypix);
 	}
 	OUTPUT:
 		RETVAL
@@ -1911,7 +1927,7 @@ GetSpeed(file=STDIN)
 			croak("Usage: Term::ReadKey::GetSpeed()");
 		}
 */
-		if(getspeed(file,&in,&out)) {
+		if(getspeed(aTHX_ file,&in,&out)) {
 			/* Failure */
 			ST( 0) = sv_newmortal();
 		} else {

--- a/genchars.pl
+++ b/genchars.pl
@@ -129,9 +129,15 @@ if(1) {
 # define LEGALMAXCC 126
 #endif
 
+#ifdef XS_INTERNAL
+#  define TRTXS(a) XS_INTERNAL(a)
+#else
+#  define TRTXS(a) XS(a)
+#endif
+
 #if defined(CC_TERMIO) || defined(CC_TERMIOS)
 
-char	* cc_names[] = {	".join('',map("
+STATIC const char	* const cc_names[] = {	".join('',map("
 #if defined($_) && ($_ < LEGALMAXCC)
 	\"$possible{$_}\",	"."
 #else				"."
@@ -139,13 +145,13 @@ char	* cc_names[] = {	".join('',map("
 #endif				", @values ))."
 };
 
-const int MAXCC = 0	",join('',map("
+STATIC const int MAXCC = 0	",join('',map("
 #if defined($_)  && ($_ < LEGALMAXCC)
 	+1		/* $possible{$_} */
 #endif			", @values ))."
 	;
 
-XS(XS_Term__ReadKey_GetControlChars)
+TRTXS(XS_Term__ReadKey_GetControlChars)
 {
 	dXSARGS;
 	if (items < 0 || items > 1) {
@@ -182,7 +188,7 @@ PUSHs(sv_2mortal(newSVpv((char*)&s.c_cc[$values[$_]],1))); 	"."
 	}
 }
 
-XS(XS_Term__ReadKey_SetControlChars)
+TRTXS(XS_Term__ReadKey_SetControlChars)
 {
 	dXSARGS;
 	/*if ((items % 2) != 0) {
@@ -363,13 +369,13 @@ print "Writing sgtty section of cchars.h... ";
 $struct
 #define TermStructure struct termstruct
 
-char	* cc_names[] = {	".join('',map("
+STATIC const char	* const cc_names[] = {	".join('',map("
 	\"$_\",			", @values ))."
 };
 
 #define MAXCC	". ($#values+1)."
 
-XS(XS_Term__ReadKey_GetControlChars)
+TRTXS(XS_Term__ReadKey_GetControlChars)
 {
 	dXSARGS;
 	if (items < 0 || items > 1) {
@@ -401,7 +407,7 @@ PUSHs(sv_2mortal(newSVpv(&s.$billy{$values[$_]},1))); 	",0..$#values))."
 	}
 }
 
-XS(XS_Term__ReadKey_SetControlChars)
+TRTXS(XS_Term__ReadKey_SetControlChars)
 {
 	dXSARGS;
 	/*if ((items % 2) != 0) {
@@ -452,7 +458,7 @@ XS(XS_Term__ReadKey_SetControlChars)
 
 #if !defined(CC_TERMIO) && !defined(CC_TERMIOS) && !defined(CC_SGTTY)
 #define TermStructure int
-XS(XS_Term__ReadKey_GetControlChars)
+TRTXS(XS_Term__ReadKey_GetControlChars)
 {
 	dXSARGS;
 	if (items <0 || items>1) {
@@ -466,7 +472,7 @@ XS(XS_Term__ReadKey_GetControlChars)
 	}
 }
 
-XS(XS_Term__ReadKey_SetControlChars)
+TRTXS(XS_Term__ReadKey_SetControlChars)
 {
 	dXSARGS;
 	if (items < 0 || items > 1) {


### PR DESCRIPTION
ReadKey.xs(543) : warning C4101: 'buffer' : unreferenced local variable
-move decl into conditional CPP blocks

ReadKey.xs(667) : warning C4101: 'i' : unreferenced local variable
-put CPP conditionals around decl

ReadKey.xs(1617) : warning C4244: 'function' : conversion from 'double' to 'DWOR
D', possible loss of data
-use DWORD everywhere, DWORD==U32, WaitForSingleObject takes integers not
 FP numbers for the timeout

-add PERL_NO_GET_CONTEXT to stop many TLS lookup function calls
 (specifically _pthread_getspecific or Perl_get_context)

-XS_INTERNAL, which contains static inside it, is only on newer perls,
 use it if available, skip creating XS_INTERNAL for old perls for now due
 to complexity