### PR TITLE
Provide a valid TAP leader

### DIFF
--- a/example/test.pl
+++ b/example/test.pl
@@ -16,7 +16,7 @@
 
 my $interactive = ( @ARGV && $ARGV[0] =~ /interactive/ );
 
-BEGIN { print "1 .. 8\n"; }
+BEGIN { print "1..8\n"; }
 END { print "not ok 1\n" unless $loaded }
 use Term::ReadKey;
 


### PR DESCRIPTION
The TAP leader is very specific and doesn't accept spaces between the numbers and dots.