### PR TITLE
Remove unused Cwd include

### DIFF
--- a/Configure.pm
+++ b/Configure.pm
@@ -48,7 +48,6 @@ require Exporter;
               GetNumericSymbol 
               GetConstants);
 
-use Cwd;
 use Config;
 
 my ($C_usrinc, $C_libpth, $C_cppstdin, $C_cppflags, $C_cppminus,


### PR DESCRIPTION
As none of the functions from the Cwd module are used, remove "use" line.

Trying to fit this into the base perl install in OpenBSD and when it tries to build, we don't yet have Cwd available and it turns out we don't need it as far as I can tell.