### PR TITLE
$(PERL) is a disk file, \$(PERLRUN) is the cmd line to run the interp

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -54,10 +54,10 @@ sub MY::top_targets {
 	$_ .= "
 
 sgtty cchars.h: genchars.pl
-	\$(PERL) -I. -I\$(PERL_LIB) genchars.pl
+	\$(PERLRUN) genchars.pl
 
 distcc: genchars.pl
-	\$(PERL) -I. -I\$(PERL_LIB) genchars.pl dist
+	\$(PERLRUN) genchars.pl dist
 
 ReadKey.c: cchars.h
 


### PR DESCRIPTION
Don't hand-roll the -Is. Let EUMM do it. The previous code was not
compatible with Win32 miniperl when ReadKey is cored in cperl.