### PR TITLE
support dual-life

### DIFF
--- a/Changes
+++ b/Changes
@@ -7,7 +7,7 @@
           harmonize formatting
         * Configure.pm, genchars.pl: reformatting, support -Dfortify_inc and cperl.
         * Makefile.PL: support ReadKey_pm.PL, add SIGN, fix pure_site_install,
-          fix realclean
+          support dual-life, fix realclean
         * META.yml: removed, auto-generated with make dist
 
 2015-06-04  Jonathan Stowe <jns+git@gellyfish.co.uk>

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -59,6 +59,14 @@ ReadKey.c: cchars.h
     $_
 }
 
+# The template needs DynaLoader. don't use miniperl (dual-life only)
+sub MY::processPL {
+    my $self = shift;
+    $_ = $self->MM::processPL();
+    s/\$\(PERLRUN\)/\$(FULLPERLRUN)/;
+    $_
+}
+
 sub MY::test {
     my $self = shift;
     $_ = $self->MM::test();

--- a/ReadKey_pm.PL
+++ b/ReadKey_pm.PL
@@ -496,6 +496,7 @@ sub GetTerminalSize
 
 close OUT;
 # preload the XS module needed for the blockoptions() expansions below
+# does not work with miniperl
 package Term::ReadKey;
 require DynaLoader;
 our @ISA = qw(DynaLoader);


### PR DESCRIPTION
the processPL section to create ReadKey.pm cannot be
performed with miniperl, which is only relevant under CORE
as dual-life module, as in cperl.