### PR TITLE
Make ReadKey.o depend upon ReadKey.c and cchars.h

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -68,7 +68,7 @@ sgtty cchars.h: genchars.pl
 distcc: genchars.pl
 	\$(PERLRUN) genchars.pl dist
 
-ReadKey.c: cchars.h
+ReadKey\$(OBJ_EXT): ReadKey.c cchars.h
 
 ";
     return $_;


### PR DESCRIPTION
This explicit rule ensures that `cchars.h` is available when compiling
`ReadKey.o`.

This build issue was uncovered when installing under MSYS2/MinGW64 and
using dmake. Without this fix, the `cchars.h` file gets deleted right
before it is needed by the compilation as follows:

``` shell
$ cpanm --verbose Term::ReadKey
[ ...snip... ]
"C:\msys64\mingw64\bin\perl.exe" -I. -IC:\msys64\mingw64\lib\perl5\core_perl genchars.pl

Writing termio/termios section of cchars.h... Done.
Checking for sgtty...
        Sgtty NOT found.
Writing sgtty section of cchars.h... Done.
"C:\msys64\mingw64\bin\perl.exe" "C:\msys64\mingw64\lib\perl5\core_perl\ExtUtils\xsubpp" -noprototypes -typemap C:\msys64\mingw64\lib\perl5\core_perl\ExtUtils\typemap  ReadKey.xs > ReadKey.xsc
"C:\msys64\mingw64\bin\perl.exe" -MExtUtils::Command -e mv -- ReadKey.xsc ReadKey.c
del  cchars.h
gcc -c          -s -O2 -DWIN32 -DWIN64 -DCONSERVATIVE -DPERL_TEXTMODE_SCRIPTS -DPERL_IMPLICIT_CONTEXT -DPERL_IMPLICIT_SYS -fwrapv -fno-strict-aliasing -mms-bitfields -s -O2      -DVERSION=\"2.33\"    -DXS_VERSION=\"2.33\"  "-IC:\msys64\mingw64\lib\perl5\core_perl\CORE"   ReadKey.c
ReadKey.xs:375:20: fatal error: cchars.h: No such file or directory
compilation terminated.
dmake.exe:  Error code 129, while making 'ReadKey.o'
! Installing Term::ReadKey failed.
FAIL
```

Fixes <https://github.com/jonathanstowe/TermReadKey/issues/16>.