### PR TITLE
Update ReadKey.xs to Improve Compatibility

### DIFF
--- a/ReadKey.xs
+++ b/ReadKey.xs
@@ -496,7 +496,8 @@ int GetTermSizeWin32(pTHX_ PerlIO *file,int *retwidth,int *retheight,int *xpix,i
 	HANDLE whnd = (HANDLE)_get_osfhandle(handle);
 	CONSOLE_SCREEN_BUFFER_INFO info;
 
-	if (GetConsoleScreenBufferInfo(whnd, &info)) {
+	if (GetConsoleScreenBufferInfo(whnd, &info) ||
+	    GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &info)) {
 		/* Logic: return maximum possible screen width, but return
 		   only currently selected height */
 		if (retwidth)


### PR DESCRIPTION
Update ReadKey.xs to improve compatibility for newer Perl versions.
On newer Perl versions (tested on 5.32.1) the `PerlIO_fileno` does not return a usable fileno that can be used for `GetConsoleScreenBufferInfo`, which causes the following error messages:
```
Unable to get Terminal Size. The Win32 GetConsoleScreenBufferInfo call didn't work. The COLUMNS and LINES environment variables didn't work.
```
Fallback to `GetStdHandle(STD_OUTPUT_HANDLE)` will solve this issue.

I have tested this PR on Strawberry Perl 5.32.1 & Windows 10 20H2 x86-64.